### PR TITLE
feat: customizable sidebar and persistent grid layout

### DIFF
--- a/prefs.py
+++ b/prefs.py
@@ -1,0 +1,33 @@
+import os
+import json
+
+GRID_PREFS_FILE = "grid_prefs.json"
+CATEGORY_PREFS_FILE = "category_prefs.json"
+
+def _load_json(path, default):
+    if os.path.exists(path):
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except Exception:
+            return default
+    return default
+
+def _save_json(path, data):
+    try:
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+    except Exception:
+        pass
+
+def load_grid_prefs():
+    return _load_json(GRID_PREFS_FILE, {})
+
+def save_grid_prefs(state):
+    _save_json(GRID_PREFS_FILE, state)
+
+def load_category_prefs():
+    return _load_json(CATEGORY_PREFS_FILE, {})
+
+def save_category_prefs(data):
+    _save_json(CATEGORY_PREFS_FILE, data)

--- a/utils.py
+++ b/utils.py
@@ -89,6 +89,7 @@ def categories_from_db(df: pd.DataFrame):
         "priorita": uniq("priorita") or ["Vysoká","Stredná","Nízka"],
         "typ_dopytu": uniq("typ_dopytu"),
         "mesto": uniq("mesto"),
+        "stav_projektu": uniq("stav_projektu"),
     }
 
 def unique_sorted(values):


### PR DESCRIPTION
## Summary
- add left sidebar with statistics and column value settings
- persist grid column order and width across sessions
- streamline header and move file import/refresh to footer

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac38bb759883248613ee91b53c0932