### PR TITLE
Move lead settings into dedicated page

### DIFF
--- a/app.py
+++ b/app.py
@@ -27,7 +27,6 @@ from prefs import (
     load_grid_prefs,
     save_grid_prefs,
     load_category_prefs,
-    save_category_prefs,
 )
 
 st.set_page_config(page_title="REMARK CRM - Leads", page_icon="📋", layout="wide")
@@ -112,26 +111,8 @@ with st.sidebar:
         unsafe_allow_html=True,
     )
     st.markdown("---")
-    st.header("Nastavenia")
-    with st.form("settings_form", clear_on_submit=False):
-        st.write("Možnosti pre stĺpce (oddelené čiarkou)")
-        stav_leadu_text = st.text_input("Stav leadu", ",".join(cats["stav_leadu"]))
-        priorita_text = st.text_input("Priorita", ",".join(cats["priorita"]))
-        stav_proj_text = st.text_input("Stav projektu", ",".join(cats.get("stav_projektu", [])))
-        typ_dopytu_text = st.text_input("Typ dopytu", ",".join(cats["typ_dopytu"]))
-        mesto_text = st.text_input("Mesto", ",".join(cats["mesto"]))
-        saved_settings = st.form_submit_button("Uložiť")
-        if saved_settings:
-            new_settings = {
-                "stav_leadu": [s.strip() for s in stav_leadu_text.split(",") if s.strip()],
-                "priorita": [s.strip() for s in priorita_text.split(",") if s.strip()],
-                "stav_projektu": [s.strip() for s in stav_proj_text.split(",") if s.strip()],
-                "typ_dopytu": [s.strip() for s in typ_dopytu_text.split(",") if s.strip()],
-                "mesto": [s.strip() for s in mesto_text.split(",") if s.strip()],
-            }
-            save_category_prefs(new_settings)
-            st.success("Uložené")
-            st.experimental_rerun()
+    if st.button("⚙️ Nastavenia", use_container_width=True):
+        st.switch_page("pages/2_Settings.py")
 
 # Header
 st.title("📋 REMARK CRM – Leads")

--- a/pages/2_Settings.py
+++ b/pages/2_Settings.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+import pandas as pd
+import streamlit as st
+
+from db import get_engine_session, fetch_leads_df
+from prefs import (
+    load_category_prefs,
+    save_category_prefs,
+    load_grid_prefs,
+    save_grid_prefs,
+)
+
+st.set_page_config(page_title="REMARK CRM - Nastavenia", page_icon="⚙️", layout="wide")
+
+st.title("⚙️ Nastavenia")
+
+engine, SessionLocal = get_engine_session()
+df = fetch_leads_df(SessionLocal)
+all_columns = [c for c in df.columns if c != "id"]
+
+# Distinct values from DB for placeholders
+cats_db = {}
+for col in all_columns:
+    cats_db[col] = sorted([str(x) for x in df[col].dropna().unique().tolist() if str(x).strip()])
+
+saved_cats = load_category_prefs()
+
+with st.form("settings_form"):
+    st.subheader("Preddefinované hodnoty")
+    selected_cols = st.multiselect(
+        "Stĺpce s výberom",
+        options=all_columns,
+        default=list(saved_cats.keys()),
+    )
+    cat_inputs = {}
+    for col in selected_cols:
+        existing = saved_cats.get(col, cats_db.get(col, []))
+        cat_inputs[col] = st.text_input(col, value=",".join(existing))
+
+    st.subheader("Poradie a šírka stĺpcov")
+    grid_prefs = load_grid_prefs()
+    col_state = grid_prefs.get("column_state", [])
+    state_map = {c["colId"]: c for c in col_state}
+    rows = []
+    for idx, col in enumerate(all_columns):
+        st_info = state_map.get(col, {})
+        rows.append({
+            "column": col,
+            "order": st_info.get("order", idx),
+            "width": st_info.get("width", ""),
+        })
+    df_state = pd.DataFrame(rows)
+    edited = st.data_editor(
+        df_state,
+        hide_index=True,
+        use_container_width=True,
+        column_config={
+            "column": st.column_config.TextColumn("Stĺpec", disabled=True),
+            "order": st.column_config.NumberColumn("Poradie"),
+            "width": st.column_config.NumberColumn("Šírka", required=False),
+        },
+    )
+
+    submitted = st.form_submit_button("Uložiť")
+    if submitted:
+        new_cats = {}
+        for col in selected_cols:
+            val = cat_inputs[col]
+            new_cats[col] = [s.strip() for s in val.split(",") if s.strip()]
+        save_category_prefs(new_cats)
+
+        new_col_state = []
+        edited_sorted = edited.sort_values("order")
+        for _, row in edited_sorted.iterrows():
+            state = {"colId": row["column"], "order": int(row["order"])}
+            if pd.notna(row["width"]) and str(row["width"]).strip() != "":
+                state["width"] = int(row["width"])
+            new_col_state.append(state)
+        save_grid_prefs({"column_state": new_col_state})
+
+        st.success("Uložené")


### PR DESCRIPTION
## Summary
- replace sidebar settings form with single button linking to settings page
- add settings page for configuring predefined column values, column order, and column widths

## Testing
- `python -m py_compile app.py pages/2_Settings.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac48e067a4832482a2dae5f191a525