### PR TITLE
Handle missing grid data when constructing DataFrame

### DIFF
--- a/app.py
+++ b/app.py
@@ -319,7 +319,11 @@ grid_resp = AgGrid(
     ],
 )
 
-current_df = pd.DataFrame(grid_resp["data"])
+grid_data = grid_resp.get("data")
+if grid_data is None:
+    current_df = df.copy()
+else:
+    current_df = pd.DataFrame(grid_data)
 selected_rows = grid_resp.get("selected_rows", [])
 
 # Detect inline edits by comparing current_df to last_grid_df for editable columns


### PR DESCRIPTION
## Summary
- Avoid ValueError when AgGrid returns no data by defaulting to existing DataFrame

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac510c66f08324892ba9bc3d7edce8