### PR TITLE
Persist SQLite DB across rebuilds

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ streamlit run app.py
   - pridávať leady manuálne cez tlačidlo **„Nový lead“**,
   - importovať Excel so stĺpcami: *Meno zákazníka, Telefón, Email, Mesto, Typ dopytu, Dátum pôvodného kontaktu, Stav projektu, Kto je konkurencia, Cena konkurencie, Naša ponuka (orientačná), Reakcia zákazníka, Dohodnutý ďalší krok, Dátum ďalšieho kroku, Priorita, Stav leadu, Orientačná cena (€), Dátum realizácie, Poznámky*,
   - alebo importovať CSV (mapovanie: `Meno`→Meno zákazníka, `Email`→Email, `Phone`→Telefón, `Vytovorene`→Dátum pôvodného kontaktu).
-- Databáza sa ukladá do súboru **remark_crm.db** v koreňovom priečinku projektu.
+- Databáza sa štandardne ukladá do súboru **/data/remark_crm.db**, ktorý sa
+  zachová aj po rebuilde aplikácie.  Cestu je možné prepísať premennou
+  prostredia `REMARK_CRM_DB`.
 
 ## Poznámky
 - Časová zóna: **Europe/Bratislava** (pre výpočty termínov).

--- a/db.py
+++ b/db.py
@@ -12,7 +12,21 @@ import io
 
 from utils import normalize_columns_generic, clean_dataframe_for_db, parse_date_safe
 
-DB_PATH = os.environ.get("REMARK_CRM_DB", "remark_crm.db")
+"""Database configuration.
+
+By default the application stored its SQLite database inside the project
+directory (``remark_crm.db``).  On platforms where the repository is
+re‑created for every deployment – such as Streamlit Cloud – this meant the
+database was wiped on each rebuild and any data entered through the app was
+lost.  The most noticeable effect was that the column
+``datum_dalsieho_kroku`` appeared empty after every new deploy.
+
+To persist data across app rebuilds we now place the database in the
+platform's persistent storage folder ``/data`` unless an explicit path is
+provided via the ``REMARK_CRM_DB`` environment variable.
+"""
+
+DB_PATH = os.environ.get("REMARK_CRM_DB", "/data/remark_crm.db")
 DATABASE_URL = f"sqlite:///{DB_PATH}"
 
 Base = declarative_base()


### PR DESCRIPTION
## Summary
- Store SQLite database in `/data/remark_crm.db` by default so data survives app rebuilds
- Document persistent database location and override mechanism in README

## Testing
- `python -m py_compile app.py db.py utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68aca7598cb48324a37aaf6be85c17af