### PR TITLE
Align next-step date formatting with original contact date

### DIFF
--- a/db.py
+++ b/db.py
@@ -167,6 +167,12 @@ def fetch_leads_df(SessionLocal) -> pd.DataFrame:
             }
             data.append(d)
         df = pd.DataFrame(data)
+        # Ensure consistent ISO formatting for date columns
+        for col in ["datum_povodneho_kontaktu", "datum_dalsieho_kroku", "datum_realizacie"]:
+            if col in df.columns:
+                dt = pd.to_datetime(df[col], errors="coerce")
+                df[col] = dt.dt.strftime("%Y-%m-%d")
+                df.loc[dt.isna(), col] = None
         return df
     finally:
         session.close()


### PR DESCRIPTION
## Summary
- Normalize date columns to ISO format when fetching leads so `datum_dalsieho_kroku` matches `datum_povodneho_kontaktu`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68acaaa6c2f8832489e1fa59b7f8ca48